### PR TITLE
Fix inflection of proper nouns ending in -ity/-ities

### DIFF
--- a/lib/Lingua/EN/Inflect/Phrase.pm
+++ b/lib/Lingua/EN/Inflect/Phrase.pm
@@ -114,6 +114,12 @@ sub _inflect_noun {
   elsif ($want_plural && lc($noun) eq 'two') {
     return 'twos';
   }
+  elsif ($noun =~ /^[A-Z].+ity\z/) {
+    return $want_plural ? ucfirst(Lingua::EN::Inflect::Number::to_PL(lc($noun))) : $noun;
+  }
+  elsif ($noun =~ /^[A-Z].+ities\z/) {
+    return $want_plural ? $noun : ucfirst(Lingua::EN::Inflect::Number::to_S(lc($noun)));
+  }
 
   if ($want_plural && (not $is_plural)) {
     return Lingua::EN::Inflect::Number::to_PL($noun);

--- a/lib/Lingua/EN/Inflect/Phrase.pm
+++ b/lib/Lingua/EN/Inflect/Phrase.pm
@@ -77,10 +77,10 @@ our @EXPORT_OK = qw/to_PL to_S/;
 
 our $prefer_nouns = 1;
 
-my $MAYBE_NOUN       = qr{(\S+)/(?:NNS?|CD|JJ)\b};
-my $MAYBE_NOUN_TAG   = qr{/(?:NNS?|CD|JJ)\b};
-my $NOUN_OR_VERB     = qr{(\S+)/(?:NNS?|CD|JJ|VB[A-Z]?)\b};
-my $NOUN_OR_VERB_TAG = qr{/(?:NNS?|CD|JJ|VB[A-Z]?)\b};
+my $MAYBE_NOUN       = qr{(\S+)/(?:NN[PS]?|CD|JJ)\b};
+my $MAYBE_NOUN_TAG   = qr{/(?:NN[PS]?|CD|JJ)\b};
+my $NOUN_OR_VERB     = qr{(\S+)/(?:NN[PS]?|CD|JJ|VB[A-Z]?)\b};
+my $NOUN_OR_VERB_TAG = qr{/(?:NN[PS]?|CD|JJ|VB[A-Z]?)\b};
 my $VERB_TAG         = qr{/VB[A-z]?\b};
 
 my $PREPOSITION_OR_CONJUNCTION_TAG = qr{/(?:CC|IN)\b};

--- a/t/basic.t
+++ b/t/basic.t
@@ -33,6 +33,10 @@ test_phrase 'swedish fish', 'swedish fish';
 # fallback
 test_phrase 'green', 'greens';
 
+# RT#118767
+test_phrase 'functionality', 'functionalities';
+test_phrase 'Functionality', 'Functionalities';
+
 Test::NoWarnings::had_no_warnings;
 
 done_testing;


### PR DESCRIPTION
This PR is another submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/january.html).

This implements a fix for [RT#118767](https://rt.cpan.org/Ticket/Display.html?id=118767) to correctly inflect proper nouns like "Functionality".